### PR TITLE
sheets that hat the /xl prefix in their path previously broke the xls…

### DIFF
--- a/lib/xlsx_reader/conversion.ex
+++ b/lib/xlsx_reader/conversion.ex
@@ -157,9 +157,6 @@ defmodule XlsxReader.Conversion do
   @spec to_decimal(String.t()) :: {:ok, Decimal.t()} | :error
   def to_decimal(string) do
     case Decimal.parse(string) do
-      {:ok, decimal} ->
-        {:ok, decimal}
-
       {decimal, ""} ->
         {:ok, decimal}
 

--- a/lib/xlsx_reader/package_loader.ex
+++ b/lib/xlsx_reader/package_loader.ex
@@ -72,6 +72,7 @@ defmodule XlsxReader.PackageLoader do
   def load_sheet_by_rid(package, rid, options \\ []) do
     case fetch_rel_target(package.workbook.rels, :sheets, rid) do
       {:ok, target} ->
+        target = String.trim_leading(target, "/xl")
         load_worksheet_xml(package, xl_path(target), options)
 
       :error ->


### PR DESCRIPTION
…x-loader, so we remove that prefix before loading